### PR TITLE
Add company logo thumbnail markup

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -7,6 +7,7 @@
     {% for job in latestJobs %}
     	<li class='job'>
     		<a href='{{ path('job-by-id-title', {id: job.jobid, title: slugify(job.position)}) }}'>
+    			<img class='left company-logo-thumbnail' src='{{job.companylogo}}' />
 	    		<span class="company">{{job.companyname}}</span>
 	    		<span class="right date show-for-medium-up">{{job.dateadded_unixtime|date('M d')}}</span>
                 <span class="right source show-for-medium-up">{{job.sourcename}}</span>


### PR DESCRIPTION
Adding a thumbnail size company logo to the left of each li will make each row visually different and easier to click on.  If no logo is present, the img will have height width of 48px to be an empty placeholder div.
